### PR TITLE
feat: add custom option when init memberlist

### DIFF
--- a/ftlib/consensus/gossip/impl.py
+++ b/ftlib/consensus/gossip/impl.py
@@ -14,7 +14,12 @@ from ftlib.consensus.consensus_status import ConsensusMode, ConsensusStatus
 #####################################################################
 class Gossip(BasicConsensus):
     def __init__(
-        self, ftlib, known_addr_list, log_file="/tmp/memberlist.log",
+        self,
+        ftlib,
+        known_addr_list,
+        log_file="/tmp/memberlist.log",
+        custom_bind_addr="",
+        custom_advertise_addr="",
     ):
         super(Gossip, self).__init__()
 
@@ -30,7 +35,11 @@ class Gossip(BasicConsensus):
         self._lib.join.argtypes = [self._goslice_type]
         self._lib.get_memberlist.restype = self.member_list
 
-        res = self._lib.init_memberlist(log_file.encode("utf-8"))
+        res = self._lib.init_memberlist(
+            log_file.encode("utf-8"),
+            custom_bind_addr.encode("utf-8"),
+            custom_advertise_addr.encode("utf-8"),
+        )
         if res != 0:
             raise RuntimeError("failed to initialize memberlist")
 

--- a/ftlib/consensus/gossip/memberlist/main.go
+++ b/ftlib/consensus/gossip/memberlist/main.go
@@ -21,11 +21,25 @@ func main() {
 }
 
 //export init_memberlist
-func init_memberlist(cLogFileName *C.char) C.int {
+func init_memberlist(
+    cLogFileName *C.char,
+    cBindAddr *C.char,
+    cAdvertiseAddr *C.char,
+    ) C.int {
     var err error
     config := memberlist.DefaultLocalConfig()
 
     logFileName := C.GoString(cLogFileName)
+    customBindAddr := C.GoString(cBindAddr)
+    customAdvertiseAddr := C.GoString(cAdvertiseAddr)
+
+    if customBindAddr != "" {
+        config.BindAddr = customBindAddr
+    }
+
+    if customAdvertiseAddr != "" {
+        config.AdvertiseAddr = customAdvertiseAddr
+    }
 
     if logFileName != "" {
         fmt.Printf("log file: %s\n", logFileName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

It seems some cluster configuration has prevented memberlist from determining final advertise address with default configuration. So we introduce two options for `init_memberlist`.
**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #64 

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @terrytangyuan 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
