### PR TITLE
fix: restore the old rank assign scheme

### DIFF
--- a/ftlib/impl.py
+++ b/ftlib/impl.py
@@ -46,7 +46,7 @@ class BasicFTLib:
 
         self.rank = None
         self.size = None
-        self.member_list = None
+        self.member_list = []
 
         self.consensus = None
         self.commlib = None

--- a/ftlib/rank_assign_scheme.py
+++ b/ftlib/rank_assign_scheme.py
@@ -14,6 +14,7 @@ def get_rank_size(member_list, self_identity, old_member_list=[]):
     #     str, ip (identity) of the 0-rank worker
     logging.debug("start to assigning rank")
     logging.debug("member_list: {}".format(member_list))
+    logging.debug("old_member_list: {}".format(old_member_list))
     logging.debug("self_identity: {}".format(self_identity))
     if self_identity not in member_list:
         raise RuntimeError(
@@ -25,20 +26,8 @@ def get_rank_size(member_list, self_identity, old_member_list=[]):
 
     hashed_member_dict = {hash_ip(m): m for m in member_list}
     hashed_member_list = sorted(hashed_member_dict.keys())
-
-    # To address issue on broadcast after rebuild
-    # https://github.com/caicloud/ftlib/issues/51
-    # Re-arrange the hashed_member_list
-    candidate_idx = 1
-    if hashed_member_list[0] not in old_member_list:
-        assert len(old_member_list) > 0
-        while candidate_idx < len(hashed_member_list):
-            if hashed_member_list[candidate_idx] in old_member_list:
-                break
-        assert hashed_member_list[candidate_idx] in old_member_list
-        temp = hashed_member_list[0]
-        hashed_member_list[0] = hashed_member_list[candidate_idx]
-        hashed_member_list[candidate_idx] = temp
+    logging.debug(f"hashed_member_dict = {hashed_member_dict}")
+    logging.debug(f"hashed_member_list = {hashed_member_list}")
 
     return (
         hashed_member_list.index(hash_ip(self_identity)),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

The new rank assign scheme introduced in a previous pr broke the rank assigning process.
Restoring the old one.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #69 

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @terrytangyuan 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
